### PR TITLE
Pass port to new Bunny instance

### DIFF
--- a/config/rabbit.yml
+++ b/config/rabbit.yml
@@ -1,6 +1,6 @@
 production:
   host: <%=ENV['MUMUKI_RABBIT_HOST']%>
-  port: <%=ENV['MUMUKI_RABBIT_PORT']%>
+  port: <%=ENV['MUMUKI_RABBIT_PORT']%> || 5672
   user: <%=ENV['MUMUKI_RABBIT_USERNAME']%>
   password: <%=ENV['MUMUKI_RABBIT_PASSWORD']%>
   database: <%=ENV['MUMUKI_RABBIT_DATABASE']%>

--- a/lib/mumukit/nuntius/connection.rb
+++ b/lib/mumukit/nuntius/connection.rb
@@ -15,7 +15,7 @@ class Mumukit::Nuntius::Connection
 
     def establish_connection
       raise 'Nuntius connection already established' if connected?
-      @connection = Bunny.new(host: config[:host], user: config[:user], password: config[:password])
+      @connection = Bunny.new(host: config[:host], port: config[:port], user: config[:user], password: config[:password])
     end
 
     def connected?


### PR DESCRIPTION
## :dart: Goal
Pass port to Bunny on init since it was being ignored.

## :memo: Details
Port env variable name is `MUMUKI_RABBIT_PORT` (already defined [here](https://github.com/mumuki/mumukit-nuntius/blob/4d2225fc5f88bc5e8851a754e21fe00e6c1c96c8/config/rabbit.yml#L3)).

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.
